### PR TITLE
Add course management data seeding and dashboard

### DIFF
--- a/public_html/server/app.js
+++ b/public_html/server/app.js
@@ -1,15 +1,79 @@
 const path = require('path');
 const express = require('express');
+const mysql = require('mysql2/promise');
+const dotenv = require('dotenv');
+
+dotenv.config();
 
 const app = express();
-app.use(express.json());
-
 const PORT = process.env.PORT || 3000;
 
+const pool = mysql.createPool({
+    host: process.env.DB_HOST,
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+    waitForConnections: true,
+    connectionLimit: 10,
+    queueLimit: 0
+});
+
+app.use(express.json());
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.get('/', (req, res) => {
     res.sendFile(path.join(__dirname, 'public', 'index.html'));
+});
+
+app.get('/course-management', (req, res) => {
+    res.sendFile(path.join(__dirname, 'public', 'course-management.html'));
+});
+
+app.get('/api/courses', async (req, res) => {
+    try {
+        const [courseRows] = await pool.query(
+            `SELECT id, level_code AS levelCode, name, description
+             FROM courses
+             ORDER BY display_order, id`
+        );
+
+        if (!courseRows.length) {
+            return res.json([]);
+        }
+
+        const [lessonRows] = await pool.query(
+            `SELECT course_id AS courseId, lesson_number AS lessonNumber, title, summary
+             FROM lessons
+             ORDER BY course_id, lesson_number`
+        );
+
+        const lessonsByCourse = lessonRows.reduce((acc, lesson) => {
+            if (!acc[lesson.courseId]) {
+                acc[lesson.courseId] = [];
+            }
+            acc[lesson.courseId].push({
+                lessonNumber: lesson.lessonNumber,
+                title: lesson.title,
+                summary: lesson.summary
+            });
+            return acc;
+        }, {});
+
+        const payload = courseRows.map(course => ({
+            id: course.id,
+            levelCode: course.levelCode,
+            name: course.name,
+            description: course.description,
+            lessons: (lessonsByCourse[course.id] || []).sort((a, b) => a.lessonNumber - b.lessonNumber)
+        }));
+
+        res.json(payload);
+    } catch (error) {
+        console.error('Error fetching courses and lessons:', error);
+        res.status(500).json({
+            message: 'Unable to load courses at this time.'
+        });
+    }
 });
 
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/public_html/server/database/course_lesson_seed.sql
+++ b/public_html/server/database/course_lesson_seed.sql
@@ -1,0 +1,125 @@
+-- Schema and seed data for JLPT courses and lessons
+-- Run this file against the configured database to provision
+-- course and lesson data used by the management dashboard.
+
+SET NAMES utf8mb4;
+SET FOREIGN_KEY_CHECKS = 0;
+
+CREATE TABLE IF NOT EXISTS courses (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    level_code VARCHAR(3) NOT NULL UNIQUE,
+    name VARCHAR(100) NOT NULL,
+    description TEXT,
+    display_order INT NOT NULL,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+CREATE TABLE IF NOT EXISTS lessons (
+    id INT AUTO_INCREMENT PRIMARY KEY,
+    course_id INT NOT NULL,
+    lesson_number INT NOT NULL,
+    title VARCHAR(255) NOT NULL,
+    summary TEXT,
+    is_published TINYINT(1) DEFAULT 1,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    CONSTRAINT fk_lessons_course FOREIGN KEY (course_id) REFERENCES courses(id) ON DELETE CASCADE,
+    CONSTRAINT uq_course_lesson UNIQUE (course_id, lesson_number)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+SET FOREIGN_KEY_CHECKS = 1;
+
+INSERT INTO courses (level_code, name, description, display_order) VALUES
+    ('N5', 'JLPT N5', 'Foundational Japanese for absolute beginners.', 1),
+    ('N4', 'JLPT N4', 'Lower-intermediate Japanese grammar and vocabulary.', 2),
+    ('N3', 'JLPT N3', 'Bridge level with intermediate grammar patterns.', 3),
+    ('N2', 'JLPT N2', 'Upper-intermediate Japanese for academic and professional contexts.', 4),
+    ('N1', 'JLPT N1', 'Advanced Japanese with native-level comprehension.', 5)
+ON DUPLICATE KEY UPDATE
+    name = VALUES(name),
+    description = VALUES(description),
+    display_order = VALUES(display_order);
+
+DELETE FROM lessons;
+
+INSERT INTO lessons (course_id, lesson_number, title, summary, is_published) VALUES
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 1, 'Lesson 1: Hiragana Basics', 'Master the first set of Japanese phonetic characters.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 2, 'Lesson 2: Greetings and Introductions', 'Learn essential phrases for meeting new people.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 3, 'Lesson 3: Daily Activities Vocabulary', 'Talk about your daily routine using simple verbs.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 4, 'Lesson 4: Numbers and Counters', 'Count objects, people, and money with confidence.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 5, 'Lesson 5: Basic Sentence Structure', 'Combine nouns, particles, and verbs into sentences.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 6, 'Lesson 6: Family and Relationships', 'Introduce your family members and describe relationships.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 7, 'Lesson 7: Time Expressions', 'Explain the time and talk about schedules.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 8, 'Lesson 8: Adjectives and Descriptions', 'Use i-adjectives and na-adjectives to describe objects.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 9, 'Lesson 9: Asking Questions', 'Form polite questions with ka and interrogative words.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 10, 'Lesson 10: Shopping Phrases', 'Buy items and ask for prices in stores.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 11, 'Lesson 11: Verb Te-form Basics', 'Connect verbs and make simple requests with te-form.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 12, 'Lesson 12: Locations and Directions', 'Give and follow basic directions.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 13, 'Lesson 13: Particles Review', 'Reinforce particle usage with practical exercises.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 14, 'Lesson 14: Likes and Dislikes', 'Express preferences using suki and kirai.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 15, 'Lesson 15: Weather and Seasons', 'Discuss weather conditions and seasonal activities.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 16, 'Lesson 16: Verb Past Tense', 'Talk about past events using ta-form.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 17, 'Lesson 17: Invitations and Plans', 'Make plans and invite friends politely.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 18, 'Lesson 18: Transportation Vocabulary', 'Navigate trains, buses, and taxis in Japanese.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 19, 'Lesson 19: Restaurant Conversations', 'Order food and drinks at Japanese eateries.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 20, 'Lesson 20: Giving Reasons with kara', 'Explain why something happens using kara.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 21, 'Lesson 21: Verb Potential Form', 'Talk about what you can and cannot do.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 22, 'Lesson 22: Invitations with mashou', 'Suggest plans using mashou and volitional forms.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 23, 'Lesson 23: Requests with kudasai', 'Ask for help politely in different situations.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 24, 'Lesson 24: Comparisons with yori', 'Compare objects and preferences.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N5'), 25, 'Lesson 25: Review and Practice', 'Wrap up N5 concepts with integrated practice.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 1, 'Lesson 1: Keigo Essentials', 'Introductory honorific and humble forms for politeness.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 2, 'Lesson 2: Complex Sentence Patterns', 'Combine clauses with ga, keredo, and noni.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 3, 'Lesson 3: Verb Te-iru Nuances', 'Express ongoing actions and resultant states.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 4, 'Lesson 4: Expressing Obligation', 'Use nakereba naranai and to ikemasen structures.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 5, 'Lesson 5: Expressing Ability and Permission', 'Review potential forms and practice temo ii desu.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 6, 'Lesson 6: Wishes and Intentions', 'Learn tai, hoshii, and volitional expressions.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 7, 'Lesson 7: Giving and Receiving Verbs', 'Master ageru, kureru, and morau usage.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 8, 'Lesson 8: Expressing Experience', 'Use koto ga aru to talk about past experiences.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 9, 'Lesson 9: Conditional Forms', 'Practice tara, to, ba, and nara conditionals.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 10, 'Lesson 10: Casual Speech Patterns', 'Switch between polite and plain forms naturally.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 11, 'Lesson 11: Expressing Purpose', 'Use tame ni and you ni for goals and purposes.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 12, 'Lesson 12: Transitive vs. Intransitive Verbs', 'Differentiate verb pairs in daily contexts.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 13, 'Lesson 13: Describing Preparations', 'Use teoku and teoku ita to talk about prep work.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 14, 'Lesson 14: Expressing Hearsay', 'Practice sou da and rashii for reported speech.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 15, 'Lesson 15: Expressing Attempts', 'Use you to suru and te miru structures.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 16, 'Lesson 16: Passive Voice Introduction', 'Create sentences using passive verb forms.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 17, 'Lesson 17: Causative Basics', 'Make someone do something with saseru forms.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 18, 'Lesson 18: Expressing Excess', 'Use sugiru and gatai to describe extremes.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 19, 'Lesson 19: Expressing While Doing', 'Combine verbs with nagara for simultaneous actions.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N4'), 20, 'Lesson 20: Review and Practice', 'Consolidate N4 grammar with dialogues.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 1, 'Lesson 1: Nuanced Particles', 'Deepen understanding of particles such as wa vs. mo.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 2, 'Lesson 2: Advanced Te-form Uses', 'Explore te-form idioms and advanced linking.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 3, 'Lesson 3: Expressing Concessions', 'Learn temoii, temo, and noni variations.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 4, 'Lesson 4: Emphasis Structures', 'Use wake, hazu, and teki for nuance.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 5, 'Lesson 5: Expressing Probability', 'Practice darou, kamo shirenai, and ni chigainai.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 6, 'Lesson 6: Passive Causative Review', 'Combine passive and causative verb forms.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 7, 'Lesson 7: Formal Expressions', 'Use keigo in business scenarios.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 8, 'Lesson 8: Relative Clauses', 'Build complex noun-modifying clauses.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 9, 'Lesson 9: Expressing Intentions', 'Use tsumori, yotei, and ni shite wa.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 10, 'Lesson 10: Idiomatic Expressions', 'Learn natural phrases for everyday speech.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 11, 'Lesson 11: Written Japanese Styles', 'Understand formal structures found in print.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 12, 'Lesson 12: Expressing Gradual Change', 'Practice you ni naru and tsutsu aru patterns.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 13, 'Lesson 13: Hypothetical Expressions', 'Use toshitara and to sureba for hypotheticals.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 14, 'Lesson 14: Expressing Emotions', 'Convey feelings with bakari and kurai.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N3'), 15, 'Lesson 15: Review and Practice', 'Integrate N3 grammar with reading drills.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 1, 'Lesson 1: Academic Reading Strategies', 'Approach long-form passages efficiently.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 2, 'Lesson 2: Nuanced Conditionals', 'Contrast toshite mo, temo, and ba forms.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 3, 'Lesson 3: Formal Written Expressions', 'Study expressions common in reports and essays.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 4, 'Lesson 4: Advanced Honorifics', 'Refine sonkeigo and kenjougo in context.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 5, 'Lesson 5: Expressing Criticism', 'Use toshite and te wa naranai to critique.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 6, 'Lesson 6: Emphatic Structures', 'Study hazu ga nai, wake ni wa ikanai, and more.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 7, 'Lesson 7: Academic Vocabulary', 'Develop reading proficiency with N2 kanji.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 8, 'Lesson 8: Expressing Simultaneity', 'Use ippou, tsutsu, and kagiri.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 9, 'Lesson 9: Persuasive Writing', 'Craft opinions using koto ni naru and mono da.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N2'), 10, 'Lesson 10: Review and Practice', 'Synthesize N2 grammar with essays.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N1'), 1, 'Lesson 1: Advanced Reading Comprehension', 'Interpret scholarly Japanese texts.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N1'), 2, 'Lesson 2: Nuanced Vocabulary', 'Study idioms and rare expressions.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N1'), 3, 'Lesson 3: Hypothetical Discourse', 'Use toshita tokoro de and tomo for speculation.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N1'), 4, 'Lesson 4: Expressing Contradiction', 'Master kadokoro ka, monononagara, and more.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N1'), 5, 'Lesson 5: Formal Speechcraft', 'Deliver polished speeches and presentations.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N1'), 6, 'Lesson 6: Academic Listening Practice', 'Decipher lectures and debates.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N1'), 7, 'Lesson 7: Expressing Nuanced Emotions', 'Use bakarika, node wa nai, and saredo.', 1),
+    ((SELECT id FROM courses WHERE level_code = 'N1'), 8, 'Lesson 8: Review and Practice', 'Bring together advanced patterns with case studies.', 1);
+

--- a/public_html/server/public/course-management.html
+++ b/public_html/server/public/course-management.html
@@ -1,0 +1,443 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Course &amp; Lesson Management</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&amp;family=Montserrat:wght@400;600;700&amp;display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --accent-dark: #7c011d;
+            --accent-light: #f8cdd4;
+            --accent-medium: #dd4f68;
+            --bg: #fff3f6;
+            --text: #3a1a27;
+            --shadow: rgba(124, 1, 29, 0.15);
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: 'Montserrat', 'Comfortaa', sans-serif;
+            background: var(--bg);
+            color: var(--text);
+            min-height: 100vh;
+            display: flex;
+            flex-direction: column;
+        }
+
+        header {
+            background: linear-gradient(180deg, #ff627a 0%, #ff3d5f 100%);
+            padding: 1.5rem 1rem 2.5rem;
+            position: relative;
+            box-shadow: 0 8px 20px rgba(255, 61, 95, 0.3);
+        }
+
+        header::after {
+            content: '';
+            position: absolute;
+            left: 50%;
+            transform: translateX(-50%);
+            bottom: -36px;
+            width: 260px;
+            height: 72px;
+            background:
+                radial-gradient(circle at 20% 50%, rgba(255, 255, 255, 0.85) 0 16%, transparent 18%),
+                radial-gradient(circle at 40% 40%, rgba(255, 255, 255, 0.75) 0 16%, transparent 18%),
+                radial-gradient(circle at 60% 60%, rgba(255, 255, 255, 0.7) 0 16%, transparent 18%),
+                radial-gradient(circle at 80% 45%, rgba(255, 255, 255, 0.8) 0 16%, transparent 18%),
+                linear-gradient(180deg, rgba(255, 170, 186, 0.7), rgba(255, 118, 152, 0.85));
+            border-radius: 40px;
+            pointer-events: none;
+        }
+
+        .page-title {
+            text-align: center;
+            color: #fff;
+            margin: 0;
+            font-size: 1.75rem;
+            letter-spacing: 0.08em;
+            text-transform: uppercase;
+        }
+
+        .level-tabs {
+            margin: 1.5rem auto 0;
+            display: flex;
+            justify-content: center;
+            gap: 0.75rem;
+            flex-wrap: wrap;
+            position: relative;
+            z-index: 1;
+        }
+
+        .level-tab {
+            border: none;
+            border-radius: 50px;
+            padding: 0.65rem 1.85rem;
+            font-size: 1rem;
+            font-weight: 700;
+            background: rgba(255, 255, 255, 0.75);
+            color: var(--accent-dark);
+            cursor: pointer;
+            transition: transform 0.2s ease, box-shadow 0.2s ease, background 0.2s ease;
+        }
+
+        .level-tab:focus-visible {
+            outline: 3px solid rgba(255, 255, 255, 0.8);
+            outline-offset: 2px;
+        }
+
+        .level-tab.is-active {
+            background: #fff;
+            transform: translateY(-4px);
+            box-shadow: 0 6px 18px rgba(124, 1, 29, 0.25);
+        }
+
+        main {
+            padding: 6rem 1rem 3rem;
+            width: min(1080px, 100%);
+            margin: 0 auto;
+        }
+
+        .course-heading {
+            text-align: center;
+            margin-bottom: 1rem;
+        }
+
+        .course-heading h2 {
+            margin: 0;
+            font-size: 1.5rem;
+            color: var(--accent-dark);
+        }
+
+        .course-heading p {
+            margin: 0.35rem 0 0;
+            color: rgba(58, 26, 39, 0.7);
+        }
+
+        .lessons-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fill, minmax(180px, 1fr));
+            gap: 1.5rem;
+            padding: 1rem 0 2rem;
+        }
+
+        .lesson-card {
+            background: var(--accent-light);
+            border-radius: 28px;
+            padding: 1.75rem 0.5rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            text-align: center;
+            flex-direction: column;
+            box-shadow: 0 12px 24px var(--shadow);
+            position: relative;
+            overflow: hidden;
+        }
+
+        .lesson-card::before {
+            content: '';
+            position: absolute;
+            inset: 12px;
+            border-radius: 20px;
+            background: rgba(255, 255, 255, 0.35);
+            z-index: 0;
+        }
+
+        .lesson-number {
+            position: relative;
+            z-index: 1;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 80px;
+            padding: 0.4rem 1rem;
+            border-radius: 999px;
+            background: var(--accent-dark);
+            color: #fff;
+            font-weight: 700;
+            letter-spacing: 0.05em;
+            margin-bottom: 0.6rem;
+        }
+
+        .lesson-title {
+            position: relative;
+            z-index: 1;
+            font-size: 0.95rem;
+            line-height: 1.4;
+            padding: 0 1rem;
+        }
+
+        .status-message {
+            text-align: center;
+            color: rgba(58, 26, 39, 0.6);
+            font-style: italic;
+        }
+
+        @media (max-width: 600px) {
+            header::after {
+                bottom: -28px;
+                width: 200px;
+            }
+
+            .level-tab {
+                padding: 0.55rem 1.5rem;
+                font-size: 0.9rem;
+            }
+
+            main {
+                padding-top: 5.5rem;
+            }
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <h1 class="page-title">JLPT Course Manager</h1>
+        <nav class="level-tabs" aria-label="JLPT level selector"></nav>
+    </header>
+    <main>
+        <div class="course-heading" aria-live="polite">
+            <h2 id="courseTitle">Select a level</h2>
+            <p id="courseDescription"></p>
+        </div>
+        <p class="status-message" id="statusMessage">Loading courses&hellip;</p>
+        <section class="lessons-grid" id="lessonsGrid" aria-live="polite"></section>
+    </main>
+
+    <template id="lessonCardTemplate">
+        <article class="lesson-card">
+            <span class="lesson-number"></span>
+            <span class="lesson-title"></span>
+        </article>
+    </template>
+
+    <script>
+        const levelTabsContainer = document.querySelector('.level-tabs');
+        const lessonsGrid = document.getElementById('lessonsGrid');
+        const courseTitle = document.getElementById('courseTitle');
+        const courseDescription = document.getElementById('courseDescription');
+        const statusMessage = document.getElementById('statusMessage');
+        const lessonCardTemplate = document.getElementById('lessonCardTemplate');
+
+        const sampleCourses = [
+            {
+                levelCode: 'N5',
+                name: 'JLPT N5',
+                description: 'Foundational Japanese for absolute beginners.',
+                lessons: [
+                    { lessonNumber: 1, title: 'Lesson 1: Hiragana Basics' },
+                    { lessonNumber: 2, title: 'Lesson 2: Greetings and Introductions' },
+                    { lessonNumber: 3, title: 'Lesson 3: Daily Activities Vocabulary' },
+                    { lessonNumber: 4, title: 'Lesson 4: Numbers and Counters' },
+                    { lessonNumber: 5, title: 'Lesson 5: Basic Sentence Structure' },
+                    { lessonNumber: 6, title: 'Lesson 6: Family and Relationships' },
+                    { lessonNumber: 7, title: 'Lesson 7: Time Expressions' },
+                    { lessonNumber: 8, title: 'Lesson 8: Adjectives and Descriptions' },
+                    { lessonNumber: 9, title: 'Lesson 9: Asking Questions' },
+                    { lessonNumber: 10, title: 'Lesson 10: Shopping Phrases' },
+                    { lessonNumber: 11, title: 'Lesson 11: Verb Te-form Basics' },
+                    { lessonNumber: 12, title: 'Lesson 12: Locations and Directions' },
+                    { lessonNumber: 13, title: 'Lesson 13: Particles Review' },
+                    { lessonNumber: 14, title: 'Lesson 14: Likes and Dislikes' },
+                    { lessonNumber: 15, title: 'Lesson 15: Weather and Seasons' },
+                    { lessonNumber: 16, title: 'Lesson 16: Verb Past Tense' },
+                    { lessonNumber: 17, title: 'Lesson 17: Invitations and Plans' },
+                    { lessonNumber: 18, title: 'Lesson 18: Transportation Vocabulary' },
+                    { lessonNumber: 19, title: 'Lesson 19: Restaurant Conversations' },
+                    { lessonNumber: 20, title: 'Lesson 20: Giving Reasons with kara' },
+                    { lessonNumber: 21, title: 'Lesson 21: Verb Potential Form' },
+                    { lessonNumber: 22, title: 'Lesson 22: Invitations with mashou' },
+                    { lessonNumber: 23, title: 'Lesson 23: Requests with kudasai' },
+                    { lessonNumber: 24, title: 'Lesson 24: Comparisons with yori' },
+                    { lessonNumber: 25, title: 'Lesson 25: Review and Practice' }
+                ]
+            },
+            {
+                levelCode: 'N4',
+                name: 'JLPT N4',
+                description: 'Lower-intermediate Japanese grammar and vocabulary.',
+                lessons: [
+                    { lessonNumber: 1, title: 'Lesson 1: Keigo Essentials' },
+                    { lessonNumber: 2, title: 'Lesson 2: Complex Sentence Patterns' },
+                    { lessonNumber: 3, title: 'Lesson 3: Verb Te-iru Nuances' },
+                    { lessonNumber: 4, title: 'Lesson 4: Expressing Obligation' },
+                    { lessonNumber: 5, title: 'Lesson 5: Expressing Ability and Permission' },
+                    { lessonNumber: 6, title: 'Lesson 6: Wishes and Intentions' },
+                    { lessonNumber: 7, title: 'Lesson 7: Giving and Receiving Verbs' },
+                    { lessonNumber: 8, title: 'Lesson 8: Expressing Experience' },
+                    { lessonNumber: 9, title: 'Lesson 9: Conditional Forms' },
+                    { lessonNumber: 10, title: 'Lesson 10: Casual Speech Patterns' },
+                    { lessonNumber: 11, title: 'Lesson 11: Expressing Purpose' },
+                    { lessonNumber: 12, title: 'Lesson 12: Transitive vs. Intransitive Verbs' },
+                    { lessonNumber: 13, title: 'Lesson 13: Describing Preparations' },
+                    { lessonNumber: 14, title: 'Lesson 14: Expressing Hearsay' },
+                    { lessonNumber: 15, title: 'Lesson 15: Expressing Attempts' },
+                    { lessonNumber: 16, title: 'Lesson 16: Passive Voice Introduction' },
+                    { lessonNumber: 17, title: 'Lesson 17: Causative Basics' },
+                    { lessonNumber: 18, title: 'Lesson 18: Expressing Excess' },
+                    { lessonNumber: 19, title: 'Lesson 19: Expressing While Doing' },
+                    { lessonNumber: 20, title: 'Lesson 20: Review and Practice' }
+                ]
+            },
+            {
+                levelCode: 'N3',
+                name: 'JLPT N3',
+                description: 'Bridge level with intermediate grammar patterns.',
+                lessons: [
+                    { lessonNumber: 1, title: 'Lesson 1: Nuanced Particles' },
+                    { lessonNumber: 2, title: 'Lesson 2: Advanced Te-form Uses' },
+                    { lessonNumber: 3, title: 'Lesson 3: Expressing Concessions' },
+                    { lessonNumber: 4, title: 'Lesson 4: Emphasis Structures' },
+                    { lessonNumber: 5, title: 'Lesson 5: Expressing Probability' },
+                    { lessonNumber: 6, title: 'Lesson 6: Passive Causative Review' },
+                    { lessonNumber: 7, title: 'Lesson 7: Formal Expressions' },
+                    { lessonNumber: 8, title: 'Lesson 8: Relative Clauses' },
+                    { lessonNumber: 9, title: 'Lesson 9: Expressing Intentions' },
+                    { lessonNumber: 10, title: 'Lesson 10: Idiomatic Expressions' },
+                    { lessonNumber: 11, title: 'Lesson 11: Written Japanese Styles' },
+                    { lessonNumber: 12, title: 'Lesson 12: Expressing Gradual Change' },
+                    { lessonNumber: 13, title: 'Lesson 13: Hypothetical Expressions' },
+                    { lessonNumber: 14, title: 'Lesson 14: Expressing Emotions' },
+                    { lessonNumber: 15, title: 'Lesson 15: Review and Practice' }
+                ]
+            },
+            {
+                levelCode: 'N2',
+                name: 'JLPT N2',
+                description: 'Upper-intermediate Japanese for academic and professional contexts.',
+                lessons: [
+                    { lessonNumber: 1, title: 'Lesson 1: Academic Reading Strategies' },
+                    { lessonNumber: 2, title: 'Lesson 2: Nuanced Conditionals' },
+                    { lessonNumber: 3, title: 'Lesson 3: Formal Written Expressions' },
+                    { lessonNumber: 4, title: 'Lesson 4: Advanced Honorifics' },
+                    { lessonNumber: 5, title: 'Lesson 5: Expressing Criticism' },
+                    { lessonNumber: 6, title: 'Lesson 6: Emphatic Structures' },
+                    { lessonNumber: 7, title: 'Lesson 7: Academic Vocabulary' },
+                    { lessonNumber: 8, title: 'Lesson 8: Expressing Simultaneity' },
+                    { lessonNumber: 9, title: 'Lesson 9: Persuasive Writing' },
+                    { lessonNumber: 10, title: 'Lesson 10: Review and Practice' }
+                ]
+            },
+            {
+                levelCode: 'N1',
+                name: 'JLPT N1',
+                description: 'Advanced Japanese with native-level comprehension.',
+                lessons: [
+                    { lessonNumber: 1, title: 'Lesson 1: Advanced Reading Comprehension' },
+                    { lessonNumber: 2, title: 'Lesson 2: Nuanced Vocabulary' },
+                    { lessonNumber: 3, title: 'Lesson 3: Hypothetical Discourse' },
+                    { lessonNumber: 4, title: 'Lesson 4: Expressing Contradiction' },
+                    { lessonNumber: 5, title: 'Lesson 5: Formal Speechcraft' },
+                    { lessonNumber: 6, title: 'Lesson 6: Academic Listening Practice' },
+                    { lessonNumber: 7, title: 'Lesson 7: Expressing Nuanced Emotions' },
+                    { lessonNumber: 8, title: 'Lesson 8: Review and Practice' }
+                ]
+            }
+        ];
+
+        const useMockData = new URLSearchParams(window.location.search).get('mock') === 'true';
+
+        let courses = [];
+        let activeLevel = '';
+
+        function setActiveLevel(levelCode) {
+            activeLevel = levelCode;
+            document.querySelectorAll('.level-tab').forEach(button => {
+                button.classList.toggle('is-active', button.dataset.level === levelCode);
+            });
+        }
+
+        function renderLessons(course) {
+            lessonsGrid.innerHTML = '';
+
+            if (!course || !course.lessons || !course.lessons.length) {
+                statusMessage.textContent = 'No lessons found for this level yet.';
+                statusMessage.hidden = false;
+                return;
+            }
+
+            statusMessage.hidden = true;
+
+            course.lessons.forEach(lesson => {
+                const card = lessonCardTemplate.content.firstElementChild.cloneNode(true);
+                card.querySelector('.lesson-number').textContent = `Lesson ${lesson.lessonNumber}`;
+                card.querySelector('.lesson-title').textContent = lesson.title;
+                lessonsGrid.appendChild(card);
+            });
+        }
+
+        function renderCourse(course) {
+            if (!course) {
+                courseTitle.textContent = 'Select a level';
+                courseDescription.textContent = '';
+                lessonsGrid.innerHTML = '';
+                statusMessage.hidden = false;
+                return;
+            }
+
+            courseTitle.textContent = `${course.levelCode} · ${course.name}`;
+            courseDescription.textContent = course.description || '';
+            renderLessons(course);
+        }
+
+        function handleLevelSelection(course) {
+            if (!course) return;
+            setActiveLevel(course.levelCode);
+            renderCourse(course);
+        }
+
+        function buildLevelTabs() {
+            levelTabsContainer.innerHTML = '';
+            courses.forEach((course, index) => {
+                const button = document.createElement('button');
+                button.type = 'button';
+                button.className = 'level-tab';
+                button.dataset.level = course.levelCode;
+                button.textContent = course.levelCode;
+                button.addEventListener('click', () => handleLevelSelection(course));
+                levelTabsContainer.appendChild(button);
+                if (index === 0) {
+                    handleLevelSelection(course);
+                }
+            });
+
+            if (!courses.length) {
+                statusMessage.textContent = 'No courses found. Please seed the database.';
+                statusMessage.hidden = false;
+            } else {
+                statusMessage.hidden = true;
+            }
+        }
+
+        async function loadCourses() {
+            try {
+                const response = await fetch('/api/courses');
+                if (!response.ok) {
+                    throw new Error(`Request failed with status ${response.status}`);
+                }
+
+                courses = await response.json();
+                buildLevelTabs();
+            } catch (error) {
+                console.error('Failed to load courses', error);
+                statusMessage.textContent = 'Unable to load courses right now. Please try again later.';
+                statusMessage.hidden = false;
+            }
+        }
+
+        if (useMockData) {
+            courses = sampleCourses;
+            buildLevelTabs();
+        } else {
+            loadCourses();
+        }
+    </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a MySQL connection pool, API endpoint, and course management route in the Express server
- provide a SQL seeder that creates the `courses` and `lessons` tables and populates them with JLPT data
- create a responsive course-management page that renders lessons from the API and supports optional mock data preview

## Testing
- not run (database service not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68dd3c33b2d88333bcc0f2370ceb0667