### PR TITLE
Add contact page with themed layout

### DIFF
--- a/public_html/server/app.js
+++ b/public_html/server/app.js
@@ -33,6 +33,10 @@ app.get('/course-management', (req, res) => {
     res.render('course-management', { active: 'courses' });
 });
 
+app.get('/contact', (req, res) => {
+    res.render('contact', { active: 'contact' });
+});
+
 app.get('/api/courses', async (req, res) => {
     try {
         const [courseRows] = await pool.query(

--- a/public_html/server/public/styles.css
+++ b/public_html/server/public/styles.css
@@ -323,6 +323,143 @@ body {
     margin-top: 1rem;
 }
 
+/* ——— Contact page ——— */
+.contact {
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+}
+
+.contact-layout {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) minmax(260px, 0.9fr);
+    gap: 2.5rem;
+    align-items: start;
+}
+
+.contact-card {
+    background: var(--soft-cream);
+    border-radius: 40px;
+    padding: 2.5rem 3rem;
+    border: 5px solid var(--accent-pink);
+    box-shadow: 0 20px 45px rgba(191, 29, 45, 0.15);
+}
+
+.contact-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-size: 0.9rem;
+}
+
+.contact-card h2 {
+    font-size: 1.75rem;
+    margin: 1.5rem 0 1rem;
+}
+
+.contact-text {
+    color: var(--text-muted);
+    font-weight: 500;
+    line-height: 1.6;
+}
+
+.contact-list {
+    margin: 2rem 0 0;
+    display: grid;
+    gap: 1.2rem;
+}
+
+.contact-item {
+    background: #fff;
+    border-radius: 24px;
+    padding: 1rem 1.4rem;
+    border: 3px solid var(--accent-pink);
+    box-shadow: 0 10px 28px rgba(191, 29, 45, 0.12);
+}
+
+.contact-item dt {
+    font-size: 0.85rem;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--text-muted);
+    margin-bottom: 0.4rem;
+}
+
+.contact-item dd {
+    margin: 0;
+    font-size: 1.05rem;
+}
+
+.contact-item a {
+    color: var(--primary-red);
+    font-weight: 600;
+    text-decoration: none;
+    transition: color 0.2s ease;
+}
+
+.contact-item a:hover,
+.contact-item a:focus {
+    color: #ff6f61;
+}
+
+.contact-footer {
+    margin-top: 2.5rem;
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.contact-visuals {
+    display: grid;
+    gap: 1.5rem;
+}
+
+.photo-placeholder {
+    background: rgba(255, 255, 255, 0.85);
+    border: 5px dashed var(--accent-pink);
+    border-radius: 32px;
+    min-height: 220px;
+    display: grid;
+    place-items: center;
+    box-shadow: 0 10px 30px rgba(191, 29, 45, 0.1);
+    text-align: center;
+    padding: 1.5rem;
+}
+
+.photo-caption {
+    font-family: 'Comfortaa', cursive;
+    font-size: 1.05rem;
+    color: var(--text-muted);
+}
+
+@media (max-width: 1100px) {
+    .contact-layout {
+        grid-template-columns: 1fr;
+    }
+
+    .contact-card {
+        order: 2;
+    }
+
+    .contact-visuals {
+        grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+        order: 1;
+    }
+}
+
+@media (max-width: 600px) {
+    .contact-card {
+        padding: 2rem;
+    }
+
+    .contact-card h2 {
+        font-size: 1.45rem;
+    }
+
+    .photo-placeholder {
+        min-height: 180px;
+    }
+}
+
 /* Optional: highlight current nav link on all pages */
 .nav a[aria-current="page"] {
     font-weight: 700;

--- a/public_html/server/public/views/contact.ejs
+++ b/public_html/server/public/views/contact.ejs
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="uk">
+    <head>
+        <meta charset="UTF-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0">
+        <title>NEKO &amp; KOI — Контакти</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com">
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+        <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet">
+        <link rel="stylesheet" href="/styles.css">
+    </head>
+    <body class="section contact">
+        <%- include('partials/nav', { active }) %>
+
+        <main class="contact-layout">
+            <section class="contact-card" aria-labelledby="contactTitle">
+                <span class="badge contact-badge">Зв'яжіться з нами</span>
+                <h2 id="contactTitle">Ми завжди раді новим знайомствам</h2>
+                <p class="contact-text">Обирайте зручний спосіб зв'язку — відповімо на всі питання про навчання, розклад і співпрацю.</p>
+
+                <dl class="contact-list">
+                    <div class="contact-item">
+                        <dt>Ел. пошта</dt>
+                        <dd><a href="mailto:hello@neko-koi.example">hello@neko-koi.example</a></dd>
+                    </div>
+                    <div class="contact-item">
+                        <dt>Telegram</dt>
+                        <dd><a href="https://t.me/neko_koi_academy" target="_blank" rel="noopener">Громадський чат NEKO &amp; KOI</a></dd>
+                    </div>
+                    <div class="contact-item">
+                        <dt>Instagram</dt>
+                        <dd><a href="https://instagram.com/neko_koi_academy" target="_blank" rel="noopener">@neko_koi_academy</a></dd>
+                    </div>
+                    <div class="contact-item">
+                        <dt>TikTok</dt>
+                        <dd><a href="https://tiktok.com/@neko_koi_academy" target="_blank" rel="noopener">@neko_koi_academy</a></dd>
+                    </div>
+                    <div class="contact-item">
+                        <dt>YouTube</dt>
+                        <dd><a href="https://youtube.com/@neko_koi_academy" target="_blank" rel="noopener">NEKO &amp; KOI Academy</a></dd>
+                    </div>
+                </dl>
+
+                <p class="contact-footer">Пишіть нам — ми на зв'язку щодня з 10:00 до 20:00 (GMT+2).</p>
+            </section>
+
+            <aside class="contact-visuals" aria-label="Місце для майбутніх фотографій">
+                <div class="photo-placeholder">
+                    <span class="photo-caption">Тут буде тепле фото команди</span>
+                </div>
+                <div class="photo-placeholder">
+                    <span class="photo-caption">А тут — наші учні та атмосфера уроків</span>
+                </div>
+            </aside>
+        </main>
+    </body>
+</html>

--- a/public_html/server/public/views/partials/nav.ejs
+++ b/public_html/server/public/views/partials/nav.ejs
@@ -7,7 +7,7 @@
         <a href="/"                 <%= active==='home'    ? 'aria-current="page"' : '' %>>Головна</a>
         <a href="/course-management"<%= active==='courses' ? 'aria-current="page"' : '' %>>Курси</a>
         <a href="#">Кана</a>
-        <a href="#">Контакти</a>
+        <a href="/contact"          <%= active==='contact' ? 'aria-current="page"' : '' %>>Контакти</a>
         <a href="#">Магазин</a>
         <a href="#">Відгуки</a>
     </nav>


### PR DESCRIPTION
## Summary
- add an Express route and navigation link for the new contact page
- create a themed contact view with mocked social/contact links and photo placeholders
- style the contact layout to match the existing soft, cute aesthetic

## Testing
- `node app.js` *(fails: missing express dependency in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de6494c83883338fe3f4667bc57865