### PR TITLE
Add registration flow and navigation auth controls

### DIFF
--- a/public_html/server/app.js
+++ b/public_html/server/app.js
@@ -2,6 +2,7 @@ const path = require('path');
 const express = require('express');
 const mysql = require('mysql2/promise');
 const dotenv = require('dotenv');
+const crypto = require('crypto');
 
 dotenv.config();
 
@@ -19,10 +20,36 @@ const pool = mysql.createPool({
 });
 
 app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.set('view engine', 'ejs');
 app.set('views', path.join(__dirname, 'public', 'views'));
+
+const hashPassword = (password) =>
+    crypto.createHash('sha256').update(password).digest('hex');
+
+const renderRegisterPage = (res, { status = 200, registerForm = {}, messages = {} } = {}) => {
+    const defaultForm = {
+        login: '',
+        profileName: '',
+        email: '',
+        subscriptionId: ''
+    };
+
+    const defaultMessages = {
+        registerErrors: [],
+        registerSuccess: null,
+        loginErrors: [],
+        loginSuccess: null
+    };
+
+    res.status(status).render('register', {
+        active: 'auth',
+        registerForm: { ...defaultForm, ...registerForm },
+        messages: { ...defaultMessages, ...messages }
+    });
+};
 
 // pages
 app.get('/', (req, res) => {
@@ -35,6 +62,172 @@ app.get('/course-management', (req, res) => {
 
 app.get('/contact', (req, res) => {
     res.render('contact', { active: 'contact' });
+});
+
+app.get('/register', (req, res) => {
+    renderRegisterPage(res);
+});
+
+app.post('/register', async (req, res) => {
+    const { login, profileName, email, password, subscriptionId } = req.body;
+    const trimmedLogin = (login || '').trim();
+    const trimmedProfileName = (profileName || '').trim();
+    const trimmedEmail = (email || '').trim();
+    const trimmedSubscriptionId = (subscriptionId || '').trim();
+    const errors = [];
+
+    if (!trimmedLogin || trimmedLogin.length < 3) {
+        errors.push('Вкажіть логін щонайменше з 3 символів.');
+    }
+
+    if (!trimmedProfileName || trimmedProfileName.length < 2) {
+        errors.push('Ім\'я профілю має містити щонайменше 2 символи.');
+    }
+
+    if (!trimmedEmail) {
+        errors.push('Вкажіть електронну адресу.');
+    } else {
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        if (!emailPattern.test(trimmedEmail)) {
+            errors.push('Електронна адреса має некоректний формат.');
+        }
+    }
+
+    if (!password || password.length < 6) {
+        errors.push('Пароль має містити щонайменше 6 символів.');
+    }
+
+    if (trimmedSubscriptionId && trimmedSubscriptionId.length > 32) {
+        errors.push('ID підписки не може бути довшим за 32 символи.');
+    }
+
+    if (errors.length) {
+        return renderRegisterPage(res, {
+            status: 400,
+            registerForm: {
+                login: trimmedLogin,
+                profileName: trimmedProfileName,
+                email: trimmedEmail,
+                subscriptionId: trimmedSubscriptionId
+            },
+            messages: { registerErrors: errors }
+        });
+    }
+
+    try {
+        const [existing] = await pool.query(
+            'SELECT id FROM users WHERE login = ? OR email = ? LIMIT 1',
+            [trimmedLogin, trimmedEmail]
+        );
+
+        if (existing.length) {
+            return renderRegisterPage(res, {
+                status: 409,
+                registerForm: {
+                    login: trimmedLogin,
+                    profileName: trimmedProfileName,
+                    email: trimmedEmail,
+                    subscriptionId: trimmedSubscriptionId
+                },
+                messages: {
+                    registerErrors: ['Користувач із таким логіном або електронною адресою вже існує.']
+                }
+            });
+        }
+
+        const passwordHash = hashPassword(password);
+
+        await pool.query(
+            `INSERT INTO users (login, profile_name, email, password_hash, subscription_id, is_admin)
+             VALUES (?, ?, ?, ?, ?, ?)`,
+            [
+                trimmedLogin,
+                trimmedProfileName,
+                trimmedEmail,
+                passwordHash,
+                trimmedSubscriptionId || null,
+                0
+            ]
+        );
+
+        return renderRegisterPage(res, {
+            messages: {
+                registerSuccess: 'Обліковий запис успішно створено! Тепер ви можете увійти.'
+            }
+        });
+    } catch (error) {
+        console.error('Error registering user:', error);
+        return renderRegisterPage(res, {
+            status: 500,
+            registerForm: {
+                login: trimmedLogin,
+                profileName: trimmedProfileName,
+                email: trimmedEmail,
+                subscriptionId: trimmedSubscriptionId
+            },
+            messages: {
+                registerErrors: ['Сталася помилка під час створення акаунта. Спробуйте ще раз пізніше.']
+            }
+        });
+    }
+});
+
+app.post('/login', async (req, res) => {
+    const { identifier, password } = req.body;
+    const trimmedIdentifier = (identifier || '').trim();
+    const errors = [];
+
+    if (!trimmedIdentifier) {
+        errors.push('Вкажіть логін або електронну адресу.');
+    }
+
+    if (!password) {
+        errors.push('Вкажіть пароль.');
+    }
+
+    if (errors.length) {
+        return renderRegisterPage(res, {
+            status: 400,
+            messages: { loginErrors: errors }
+        });
+    }
+
+    try {
+        const [rows] = await pool.query(
+            'SELECT id, login, profile_name, password_hash FROM users WHERE login = ? OR email = ? LIMIT 1',
+            [trimmedIdentifier, trimmedIdentifier]
+        );
+
+        if (!rows.length) {
+            return renderRegisterPage(res, {
+                status: 404,
+                messages: { loginErrors: ['Обліковий запис не знайдено.'] }
+            });
+        }
+
+        const user = rows[0];
+        const hashedInput = hashPassword(password);
+
+        if (user.password_hash !== hashedInput) {
+            return renderRegisterPage(res, {
+                status: 401,
+                messages: { loginErrors: ['Невірний пароль.'] }
+            });
+        }
+
+        const displayName = user.profile_name || user.login;
+        return renderRegisterPage(res, {
+            messages: { loginSuccess: `Ласкаво просимо, ${displayName}!` }
+        });
+    } catch (error) {
+        console.error('Error logging in user:', error);
+        return renderRegisterPage(res, {
+            status: 500,
+            messages: {
+                loginErrors: ['Сталася помилка під час входу. Спробуйте ще раз пізніше.']
+            }
+        });
+    }
 });
 
 app.get('/api/courses', async (req, res) => {

--- a/public_html/server/database/users_table.sql
+++ b/public_html/server/database/users_table.sql
@@ -1,0 +1,15 @@
+-- Schema for the users table utilised by NEKO & KOI Academy
+CREATE TABLE IF NOT EXISTS users (
+    id INT UNSIGNED NOT NULL AUTO_INCREMENT,
+    login VARCHAR(64) NOT NULL,
+    profile_name VARCHAR(100) NOT NULL,
+    email VARCHAR(191) NOT NULL,
+    password_hash CHAR(64) NOT NULL,
+    subscription_id VARCHAR(32) DEFAULT NULL,
+    is_admin TINYINT(1) NOT NULL DEFAULT 0,
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (id),
+    UNIQUE KEY uq_users_login (login),
+    UNIQUE KEY uq_users_email (email)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/public_html/server/public/styles.css
+++ b/public_html/server/public/styles.css
@@ -32,6 +32,12 @@ body {
     box-shadow: 0 12px 30px rgba(191, 29, 45, 0.3);
 }
 
+.navigation-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 2.5rem;
+}
+
 .logo-area h1 {
     font-family: 'Comfortaa', cursive;
     font-size: 2.2rem;
@@ -62,6 +68,50 @@ body {
 
 .nav a:hover {
     border-color: #fff;
+}
+
+.auth-actions {
+    display: flex;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.auth-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.55rem 1.4rem;
+    border-radius: 999px;
+    font-weight: 600;
+    text-decoration: none;
+    transition: transform 0.2s ease, background 0.2s ease, color 0.2s ease;
+    border: 2px solid transparent;
+}
+
+.auth-btn:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.6);
+    outline-offset: 2px;
+}
+
+.auth-btn--outline {
+    border-color: #fff;
+    color: #fff;
+}
+
+.auth-btn--outline:hover {
+    transform: translateY(-2px);
+    background: rgba(255, 255, 255, 0.12);
+}
+
+.auth-btn--solid {
+    background: #fff;
+    color: var(--primary-red);
+}
+
+.auth-btn--solid:hover {
+    transform: translateY(-2px);
+    background: var(--accent-gold);
+    color: var(--text-dark);
 }
 
 .hero {
@@ -207,8 +257,17 @@ body {
         text-align: center;
     }
 
+    .navigation-wrapper {
+        flex-direction: column;
+        gap: 1.25rem;
+    }
+
     .nav {
         flex-wrap: wrap;
+        justify-content: center;
+    }
+
+    .auth-actions {
         justify-content: center;
     }
 }
@@ -465,4 +524,146 @@ body {
     font-weight: 700;
     color: var(--accent-gold);
     border-color: #fff;
+}
+
+/* ——— Auth pages ——— */
+.auth-page {
+    display: grid;
+    gap: 2.5rem;
+}
+
+.auth-header {
+    text-align: center;
+    max-width: 720px;
+    margin: 0 auto;
+}
+
+.auth-header h1 {
+    font-size: 2rem;
+    margin-bottom: 0.75rem;
+    color: var(--primary-red);
+}
+
+.auth-header p {
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.auth-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+    gap: 2rem;
+}
+
+.auth-card {
+    background: #fff;
+    border-radius: 36px;
+    padding: 2.25rem 2.5rem;
+    border: 5px solid var(--accent-pink);
+    box-shadow: 0 18px 36px rgba(191, 29, 45, 0.12);
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+}
+
+.auth-card h2 {
+    font-size: 1.5rem;
+    color: var(--primary-red);
+}
+
+.auth-card p {
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.auth-form {
+    display: grid;
+    gap: 1rem;
+}
+
+.auth-form label {
+    display: grid;
+    gap: 0.35rem;
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.auth-form input {
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    border: 2px solid var(--accent-pink);
+    background: var(--soft-cream);
+    font-size: 1rem;
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-form input:focus {
+    outline: none;
+    border-color: var(--primary-red);
+    box-shadow: 0 0 0 3px rgba(191, 29, 45, 0.2);
+}
+
+.auth-submit {
+    margin-top: 0.5rem;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.6rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(90deg, var(--primary-red) 0%, #ff6f61 100%);
+    color: #fff;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.auth-submit:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(191, 29, 45, 0.25);
+}
+
+.auth-submit:focus-visible {
+    outline: 3px solid rgba(191, 29, 45, 0.4);
+    outline-offset: 3px;
+}
+
+.auth-alert {
+    border-radius: 18px;
+    padding: 0.9rem 1.1rem;
+    line-height: 1.5;
+    font-weight: 600;
+}
+
+.auth-alert ul {
+    margin: 0.35rem 0 0 1.1rem;
+}
+
+.auth-alert--error {
+    background: rgba(191, 29, 45, 0.12);
+    border: 2px solid rgba(191, 29, 45, 0.35);
+    color: var(--primary-red);
+}
+
+.auth-alert--success {
+    background: rgba(68, 184, 108, 0.12);
+    border: 2px solid rgba(68, 184, 108, 0.4);
+    color: #2f7a4a;
+}
+
+.auth-note {
+    font-size: 0.95rem;
+    color: var(--text-muted);
+}
+
+.auth-divider {
+    height: 1px;
+    background: rgba(191, 29, 45, 0.15);
+    border: none;
+}
+
+@media (max-width: 600px) {
+    .auth-card {
+        padding: 2rem 1.75rem;
+    }
 }

--- a/public_html/server/public/views/partials/nav.ejs
+++ b/public_html/server/public/views/partials/nav.ejs
@@ -3,12 +3,18 @@
         <h1>NEKO &amp; KOI</h1>
         <span class="subtitle">ACADEMY</span>
     </div>
-    <nav class="nav">
-        <a href="/"                 <%= active==='home'    ? 'aria-current="page"' : '' %>>Головна</a>
-        <a href="/course-management"<%= active==='courses' ? 'aria-current="page"' : '' %>>Курси</a>
-        <a href="#">Кана</a>
-        <a href="/contact"          <%= active==='contact' ? 'aria-current="page"' : '' %>>Контакти</a>
-        <a href="#">Магазин</a>
-        <a href="#">Відгуки</a>
-    </nav>
+    <div class="navigation-wrapper">
+        <nav class="nav">
+            <a href="/"                 <%= active==='home'    ? 'aria-current="page"' : '' %>>Головна</a>
+            <a href="/course-management"<%= active==='courses' ? 'aria-current="page"' : '' %>>Курси</a>
+            <a href="#">Кана</a>
+            <a href="/contact"          <%= active==='contact' ? 'aria-current="page"' : '' %>>Контакти</a>
+            <a href="#">Магазин</a>
+            <a href="#">Відгуки</a>
+        </nav>
+        <div class="auth-actions">
+            <a class="auth-btn auth-btn--outline" href="/register">Зареєструватися</a>
+            <a class="auth-btn auth-btn--solid" href="/register#login">Увійти</a>
+        </div>
+    </div>
 </header>

--- a/public_html/server/public/views/register.ejs
+++ b/public_html/server/public/views/register.ejs
@@ -1,0 +1,150 @@
+<!DOCTYPE html>
+<html lang="uk">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>NEKO & KOI Academy — Реєстрація</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Montserrat:wght@400;600;700&display=swap" rel="stylesheet" />
+        <link rel="stylesheet" href="/styles.css" />
+    </head>
+    <body>
+        <%- include('partials/nav', { active }) %>
+
+        <main class="section auth-page">
+            <header class="auth-header">
+                <h1>Створіть обліковий запис NEKO &amp; KOI</h1>
+                <p>
+                    Зареєструйтесь, щоб зберігати прогрес у навчанні, отримувати персональні рекомендації та першими дізнаватися про нові курси.
+                </p>
+            </header>
+
+            <div class="auth-grid">
+                <section class="auth-card">
+                    <h2>Реєстрація</h2>
+                    <p>
+                        Заповніть форму нижче, щоб створити акаунт. Поля, позначені зірочкою, є обов'язковими.
+                    </p>
+
+                    <% if (messages.registerSuccess) { %>
+                        <div class="auth-alert auth-alert--success"><%= messages.registerSuccess %></div>
+                    <% } %>
+
+                    <% if (messages.registerErrors && messages.registerErrors.length) { %>
+                        <div class="auth-alert auth-alert--error">
+                            <span>Будь ласка, виправте наступні помилки:</span>
+                            <ul>
+                                <% messages.registerErrors.forEach(function(error) { %>
+                                    <li><%= error %></li>
+                                <% }) %>
+                            </ul>
+                        </div>
+                    <% } %>
+
+                    <form class="auth-form" action="/register" method="post" autocomplete="on">
+                        <label for="register-login">Логін *</label>
+                        <input
+                            type="text"
+                            id="register-login"
+                            name="login"
+                            minlength="3"
+                            required
+                            autocomplete="username"
+                            value="<%= registerForm.login %>"
+                        />
+
+                        <label for="register-name">Ім'я профілю *</label>
+                        <input
+                            type="text"
+                            id="register-name"
+                            name="profileName"
+                            minlength="2"
+                            required
+                            value="<%= registerForm.profileName %>"
+                        />
+
+                        <label for="register-email">Електронна адреса *</label>
+                        <input
+                            type="email"
+                            id="register-email"
+                            name="email"
+                            required
+                            autocomplete="email"
+                            value="<%= registerForm.email %>"
+                        />
+
+                        <label for="register-password">Пароль *</label>
+                        <input
+                            type="password"
+                            id="register-password"
+                            name="password"
+                            minlength="6"
+                            required
+                            autocomplete="new-password"
+                        />
+
+                        <label for="register-subscription">ID підписки (необов'язково)</label>
+                        <input
+                            type="text"
+                            id="register-subscription"
+                            name="subscriptionId"
+                            value="<%= registerForm.subscriptionId %>"
+                        />
+
+                        <button type="submit" class="auth-submit">Створити акаунт</button>
+                    </form>
+
+                    <p class="auth-note">Реєструючись, ви погоджуєтесь із нашою політикою конфіденційності та умовами користування.</p>
+                </section>
+
+                <section class="auth-card" id="login">
+                    <h2>Увійти</h2>
+                    <p>
+                        Вже маєте акаунт? Авторизуйтеся, використовуючи свій логін або email та пароль.
+                    </p>
+
+                    <% if (messages.loginSuccess) { %>
+                        <div class="auth-alert auth-alert--success"><%= messages.loginSuccess %></div>
+                    <% } %>
+
+                    <% if (messages.loginErrors && messages.loginErrors.length) { %>
+                        <div class="auth-alert auth-alert--error">
+                            <span>Не вдалося увійти:</span>
+                            <ul>
+                                <% messages.loginErrors.forEach(function(error) { %>
+                                    <li><%= error %></li>
+                                <% }) %>
+                            </ul>
+                        </div>
+                    <% } %>
+
+                    <form class="auth-form" action="/login" method="post" autocomplete="on">
+                        <label for="login-identifier">Логін або email *</label>
+                        <input
+                            type="text"
+                            id="login-identifier"
+                            name="identifier"
+                            required
+                            autocomplete="username"
+                        />
+
+                        <label for="login-password">Пароль *</label>
+                        <input
+                            type="password"
+                            id="login-password"
+                            name="password"
+                            required
+                            minlength="6"
+                            autocomplete="current-password"
+                        />
+
+                        <button type="submit" class="auth-submit">Увійти</button>
+                    </form>
+
+                    <p class="auth-note">Забули пароль? Зверніться до адміністратора академії, щоб його скинути.</p>
+                </section>
+            </div>
+        </main>
+    </body>
+</html>


### PR DESCRIPTION
## Summary
- add registration and login form UI plus call-to-action buttons in the navigation bar
- implement registration and login handlers with input validation and SHA-256 password hashing
- provide SQL schema for the users table and styling for the new authentication screens

## Testing
- node app.js *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_68de74d86e9c8333be442bc850e56ae8