### PR TITLE
Add session-driven profile navigation and refactor auth flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@
 .ftpquota
 .htaccess
 package.json
+!public_html/server/package.json
 package-lock.json
 /public_html/node_modules/

--- a/public_html/server/controllers/AuthController.js
+++ b/public_html/server/controllers/AuthController.js
@@ -1,0 +1,100 @@
+class AuthController {
+    constructor(authService) {
+        this.authService = authService;
+
+        this.showRegister = this.showRegister.bind(this);
+        this.register = this.register.bind(this);
+        this.login = this.login.bind(this);
+        this.logout = this.logout.bind(this);
+    }
+
+    renderRegisterPage(res, options = {}) {
+        const { status = 200, registerForm = {}, messages = {} } = options;
+
+        const defaultForm = {
+            login: '',
+            profileName: '',
+            email: '',
+            subscriptionId: ''
+        };
+
+        const defaultMessages = {
+            registerErrors: [],
+            registerSuccess: null,
+            loginErrors: [],
+            loginSuccess: null
+        };
+
+        res.status(status).render('register', {
+            active: 'auth',
+            registerForm: { ...defaultForm, ...registerForm },
+            messages: { ...defaultMessages, ...messages }
+        });
+    }
+
+    showRegister(req, res) {
+        this.renderRegisterPage(res);
+    }
+
+    async register(req, res) {
+        try {
+            const result = await this.authService.registerUser(req.body);
+
+            if (!result.success) {
+                return this.renderRegisterPage(res, result);
+            }
+
+            return this.renderRegisterPage(res, result);
+        } catch (error) {
+            console.error('Error registering user:', error);
+            return this.renderRegisterPage(res, {
+                status: 500,
+                registerForm: {
+                    login: req.body.login || '',
+                    profileName: req.body.profileName || '',
+                    email: req.body.email || '',
+                    subscriptionId: req.body.subscriptionId || ''
+                },
+                messages: {
+                    registerErrors: ['Сталася помилка під час створення акаунта. Спробуйте ще раз пізніше.']
+                }
+            });
+        }
+    }
+
+    async login(req, res) {
+        try {
+            const result = await this.authService.loginUser(req.body);
+
+            if (!result.success) {
+                return this.renderRegisterPage(res, result);
+            }
+
+            req.session.user = result.user;
+            res.locals.currentUser = result.user;
+            return this.renderRegisterPage(res, {
+                status: result.status,
+                messages: result.messages
+            });
+        } catch (error) {
+            console.error('Error logging in user:', error);
+            return this.renderRegisterPage(res, {
+                status: 500,
+                messages: {
+                    loginErrors: ['Сталася помилка під час входу. Спробуйте ще раз пізніше.']
+                }
+            });
+        }
+    }
+
+    logout(req, res) {
+        req.session.destroy(error => {
+            if (error) {
+                console.error('Error destroying session during logout:', error);
+            }
+            res.redirect('/');
+        });
+    }
+}
+
+module.exports = AuthController;

--- a/public_html/server/package.json
+++ b/public_html/server/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "gb-japsite-server",
+  "version": "1.0.0",
+  "description": "Express server for NEKO & KOI Academy",
+  "main": "app.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node app.js"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.5",
+    "express": "^4.18.3",
+    "express-session": "^1.17.3",
+    "mysql2": "^3.9.7"
+  }
+}

--- a/public_html/server/public/img/avatar-default.svg
+++ b/public_html/server/public/img/avatar-default.svg
@@ -1,0 +1,11 @@
+<svg width="96" height="96" viewBox="0 0 96 96" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="grad" x1="0" y1="0" x2="96" y2="96" gradientUnits="userSpaceOnUse">
+      <stop stop-color="#BF1D2D" />
+      <stop offset="1" stop-color="#FF6F61" />
+    </linearGradient>
+  </defs>
+  <rect width="96" height="96" rx="48" fill="url(#grad)" />
+  <path d="M48 24C39.1634 24 32 31.1634 32 40C32 48.8366 39.1634 56 48 56C56.8366 56 64 48.8366 64 40C64 31.1634 56.8366 24 48 24Z" fill="white" fill-opacity="0.92" />
+  <path d="M48 63C33.0883 63 21 75.0883 21 90H75C75 75.0883 62.9117 63 48 63Z" fill="white" fill-opacity="0.88" />
+</svg>

--- a/public_html/server/public/js/nav-menu.js
+++ b/public_html/server/public/js/nav-menu.js
@@ -1,0 +1,41 @@
+(function () {
+    const profileMenu = document.querySelector('[data-profile-menu]');
+
+    if (!profileMenu) {
+        return;
+    }
+
+    const toggle = profileMenu.querySelector('[data-profile-toggle]');
+    const closeMenu = () => {
+        profileMenu.classList.remove('is-open');
+        toggle.setAttribute('aria-expanded', 'false');
+    };
+
+    const openMenu = () => {
+        profileMenu.classList.add('is-open');
+        toggle.setAttribute('aria-expanded', 'true');
+    };
+
+    toggle.addEventListener('click', event => {
+        event.stopPropagation();
+        const isOpen = profileMenu.classList.contains('is-open');
+        if (isOpen) {
+            closeMenu();
+        } else {
+            openMenu();
+        }
+    });
+
+    document.addEventListener('click', event => {
+        if (!profileMenu.contains(event.target)) {
+            closeMenu();
+        }
+    });
+
+    document.addEventListener('keydown', event => {
+        if (event.key === 'Escape') {
+            closeMenu();
+            toggle.focus();
+        }
+    });
+})();

--- a/public_html/server/public/styles.css
+++ b/public_html/server/public/styles.css
@@ -36,6 +36,7 @@ body {
     display: flex;
     align-items: center;
     gap: 2.5rem;
+    flex: 1;
 }
 
 .logo-area h1 {
@@ -68,6 +69,12 @@ body {
 
 .nav a:hover {
     border-color: #fff;
+}
+
+.auth-area {
+    display: flex;
+    align-items: center;
+    margin-left: auto;
 }
 
 .auth-actions {
@@ -112,6 +119,127 @@ body {
     transform: translateY(-2px);
     background: var(--accent-gold);
     color: var(--text-dark);
+}
+
+.profile-menu {
+    position: relative;
+    display: flex;
+    align-items: center;
+}
+
+.profile-toggle {
+    background: transparent;
+    border: none;
+    padding: 0;
+    cursor: pointer;
+    border-radius: 50%;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-toggle:focus-visible {
+    outline: 3px solid rgba(255, 255, 255, 0.7);
+    outline-offset: 4px;
+}
+
+.profile-toggle:hover {
+    transform: translateY(-1px);
+}
+
+.profile-avatar {
+    width: 44px;
+    height: 44px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 3px solid rgba(255, 255, 255, 0.6);
+    box-shadow: 0 6px 12px rgba(0, 0, 0, 0.2);
+    background: #fff;
+}
+
+.profile-dropdown {
+    position: absolute;
+    top: calc(100% + 0.75rem);
+    right: 0;
+    background: #fff;
+    color: var(--text-dark);
+    border-radius: 18px;
+    box-shadow: 0 18px 45px rgba(0, 0, 0, 0.16);
+    padding: 1rem 1.25rem;
+    min-width: 220px;
+    display: none;
+    z-index: 10;
+}
+
+.profile-menu.is-open .profile-dropdown {
+    display: block;
+}
+
+.profile-label {
+    display: block;
+    font-weight: 600;
+    margin-bottom: 0.75rem;
+    color: var(--primary-red);
+}
+
+.profile-dropdown__list {
+    list-style: none;
+    display: grid;
+    gap: 0.45rem;
+}
+
+.profile-dropdown__list a {
+    text-decoration: none;
+    color: inherit;
+    font-weight: 500;
+    padding: 0.35rem 0;
+    border-radius: 8px;
+    transition: background-color 0.2s ease, color 0.2s ease;
+}
+
+.profile-dropdown__list a:hover,
+.profile-dropdown__list a:focus-visible {
+    background-color: rgba(191, 29, 45, 0.08);
+    color: var(--primary-red);
+    outline: none;
+}
+
+.profile-dropdown__separator {
+    height: 1px;
+    background: rgba(0, 0, 0, 0.08);
+    margin: 0.85rem 0 0.6rem;
+}
+
+.profile-dropdown__logout {
+    width: 100%;
+    border: none;
+    background: linear-gradient(90deg, var(--primary-red) 0%, #ff6f61 100%);
+    color: #fff;
+    padding: 0.55rem 0.85rem;
+    border-radius: 12px;
+    font-weight: 600;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-dropdown__logout:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 20px rgba(191, 29, 45, 0.3);
+}
+
+.profile-dropdown__logout:focus-visible {
+    outline: 3px solid rgba(191, 29, 45, 0.3);
+    outline-offset: 2px;
+}
+
+.sr-only {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    padding: 0;
+    margin: -1px;
+    overflow: hidden;
+    clip: rect(0, 0, 0, 0);
+    white-space: nowrap;
+    border: 0;
 }
 
 .hero {

--- a/public_html/server/public/views/contact.ejs
+++ b/public_html/server/public/views/contact.ejs
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="/styles.css">
     </head>
     <body>
-        <%- include('partials/nav', { active }) %>
+        <%- include('partials/nav', { active, currentUser }) %>
         <main class="contact-layout section contact">
             <section class="contact-card" aria-labelledby="contactTitle">
                 <span class="badge contact-badge">Зв'яжіться з нами</span>
@@ -52,5 +52,6 @@
                 </div>
             </aside>
         </main>
+        <script src="/js/nav-menu.js" defer></script>
     </body>
 </html>

--- a/public_html/server/public/views/course-management.ejs
+++ b/public_html/server/public/views/course-management.ejs
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="styles.css">
     </head>
     <body>
-        <%- include('partials/nav', { active }) %>
+        <%- include('partials/nav', { active, currentUser }) %>
         <main class="section">
             <div class="course-heading" aria-live="polite">
                 <h2 id="courseTitle">Оберіть рівень JLPT</h2>
@@ -29,6 +29,7 @@
             </article>
         </template>
 
+        <script src="/js/nav-menu.js" defer></script>
         <script src="course-management.js"></script>
     </body>
 </html>

--- a/public_html/server/public/views/index.ejs
+++ b/public_html/server/public/views/index.ejs
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="/styles.css" />
     </head>
     <body>
-        <%- include('partials/nav', { active }) %>
+        <%- include('partials/nav', { active, currentUser }) %>
         <main class="hero section">
             <section class="hero__left">
                 <div class="left-card">
@@ -39,5 +39,6 @@
                 </div>
             </section>
         </main>
+        <script src="/js/nav-menu.js" defer></script>
     </body>
 </html>

--- a/public_html/server/public/views/partials/nav.ejs
+++ b/public_html/server/public/views/partials/nav.ejs
@@ -12,9 +12,44 @@
             <a href="#">Магазин</a>
             <a href="#">Відгуки</a>
         </nav>
-        <div class="auth-actions">
-            <a class="auth-btn auth-btn--outline" href="/register">Зареєструватися</a>
-            <a class="auth-btn auth-btn--solid" href="/register#login">Увійти</a>
+        <div class="auth-area">
+            <% if (!currentUser) { %>
+                <div class="auth-actions">
+                    <a class="auth-btn auth-btn--outline" href="/register">Зареєструватися</a>
+                    <a class="auth-btn auth-btn--solid" href="/register#login">Увійти</a>
+                </div>
+            <% } else { %>
+                <div class="profile-menu" data-profile-menu>
+                    <button
+                        class="profile-toggle"
+                        type="button"
+                        aria-haspopup="true"
+                        aria-expanded="false"
+                        data-profile-toggle
+                    >
+                        <span class="sr-only">Відкрити меню профілю</span>
+                        <img
+                            src="<%= currentUser.avatarUrl %>"
+                            alt="Профіль <%= currentUser.displayName %>"
+                            class="profile-avatar"
+                            width="44"
+                            height="44"
+                        />
+                    </button>
+                    <div class="profile-dropdown" role="menu" data-profile-dropdown>
+                        <span class="profile-label">Привіт, <%= currentUser.displayName %></span>
+                        <ul class="profile-dropdown__list">
+                            <li><a href="#" role="menuitem">Переглянути профіль</a></li>
+                            <li><a href="#" role="menuitem">Керувати підпискою</a></li>
+                            <li><a href="#" role="menuitem">Налаштування</a></li>
+                        </ul>
+                        <div class="profile-dropdown__separator" role="none"></div>
+                        <form action="/logout" method="post">
+                            <button type="submit" class="profile-dropdown__logout" role="menuitem">Вийти</button>
+                        </form>
+                    </div>
+                </div>
+            <% } %>
         </div>
     </div>
 </header>

--- a/public_html/server/public/views/register.ejs
+++ b/public_html/server/public/views/register.ejs
@@ -10,7 +10,7 @@
         <link rel="stylesheet" href="/styles.css" />
     </head>
     <body>
-        <%- include('partials/nav', { active }) %>
+        <%- include('partials/nav', { active, currentUser }) %>
 
         <main class="section auth-page">
             <header class="auth-header">
@@ -146,5 +146,6 @@
                 </section>
             </div>
         </main>
+        <script src="/js/nav-menu.js" defer></script>
     </body>
 </html>

--- a/public_html/server/services/AuthService.js
+++ b/public_html/server/services/AuthService.js
@@ -1,0 +1,153 @@
+const crypto = require('crypto');
+
+class AuthService {
+    constructor(userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    hashPassword(password) {
+        return crypto.createHash('sha256').update(password).digest('hex');
+    }
+
+    validateRegisterPayload({ login = '', profileName = '', email = '', password = '', subscriptionId = '' }) {
+        const trimmed = {
+            login: login.trim(),
+            profileName: profileName.trim(),
+            email: email.trim(),
+            subscriptionId: subscriptionId.trim()
+        };
+
+        const errors = [];
+
+        if (!trimmed.login || trimmed.login.length < 3) {
+            errors.push('Вкажіть логін щонайменше з 3 символів.');
+        }
+
+        if (!trimmed.profileName || trimmed.profileName.length < 2) {
+            errors.push('Ім\'я профілю має містити щонайменше 2 символи.');
+        }
+
+        if (!trimmed.email) {
+            errors.push('Вкажіть електронну адресу.');
+        } else {
+            const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+            if (!emailPattern.test(trimmed.email)) {
+                errors.push('Електронна адреса має некоректний формат.');
+            }
+        }
+
+        if (!password || password.length < 6) {
+            errors.push('Пароль має містити щонайменше 6 символів.');
+        }
+
+        if (trimmed.subscriptionId && trimmed.subscriptionId.length > 32) {
+            errors.push('ID підписки не може бути довшим за 32 символи.');
+        }
+
+        return { trimmed, errors };
+    }
+
+    async registerUser(payload) {
+        const { trimmed, errors } = this.validateRegisterPayload(payload);
+
+        if (errors.length) {
+            return {
+                success: false,
+                status: 400,
+                registerForm: trimmed,
+                messages: { registerErrors: errors }
+            };
+        }
+
+        const userExists = await this.userRepository.existsWithLoginOrEmail(trimmed.login, trimmed.email);
+
+        if (userExists) {
+            return {
+                success: false,
+                status: 409,
+                registerForm: trimmed,
+                messages: {
+                    registerErrors: ['Користувач із таким логіном або електронною адресою вже існує.']
+                }
+            };
+        }
+
+        const passwordHash = this.hashPassword(payload.password);
+
+        await this.userRepository.createUser({
+            login: trimmed.login,
+            profileName: trimmed.profileName,
+            email: trimmed.email,
+            passwordHash,
+            subscriptionId: trimmed.subscriptionId
+        });
+
+        return {
+            success: true,
+            status: 201,
+            registerForm: { login: '', profileName: '', email: '', subscriptionId: '' },
+            messages: {
+                registerSuccess: 'Обліковий запис успішно створено! Тепер ви можете увійти.'
+            }
+        };
+    }
+
+    async loginUser({ identifier = '', password = '' }) {
+        const trimmedIdentifier = identifier.trim();
+        const errors = [];
+
+        if (!trimmedIdentifier) {
+            errors.push('Вкажіть логін або електронну адресу.');
+        }
+
+        if (!password) {
+            errors.push('Вкажіть пароль.');
+        }
+
+        if (errors.length) {
+            return {
+                success: false,
+                status: 400,
+                messages: { loginErrors: errors }
+            };
+        }
+
+        const user = await this.userRepository.findByLoginOrEmail(trimmedIdentifier);
+
+        if (!user) {
+            return {
+                success: false,
+                status: 404,
+                messages: { loginErrors: ['Обліковий запис не знайдено.'] }
+            };
+        }
+
+        const hashedInput = this.hashPassword(password);
+
+        if (user.passwordHash !== hashedInput) {
+            return {
+                success: false,
+                status: 401,
+                messages: { loginErrors: ['Невірний пароль.'] }
+            };
+        }
+
+        const displayName = user.profileName || user.login;
+
+        return {
+            success: true,
+            user: {
+                id: user.id,
+                login: user.login,
+                profileName: user.profileName,
+                subscriptionId: user.subscriptionId,
+                displayName,
+                avatarUrl: '/img/avatar-default.svg'
+            },
+            status: 200,
+            messages: { loginSuccess: `Ласкаво просимо, ${displayName}!` }
+        };
+    }
+}
+
+module.exports = AuthService;

--- a/public_html/server/services/UserRepository.js
+++ b/public_html/server/services/UserRepository.js
@@ -1,0 +1,31 @@
+class UserRepository {
+    constructor(pool) {
+        this.pool = pool;
+    }
+
+    async findByLoginOrEmail(identifier) {
+        const [rows] = await this.pool.query(
+            'SELECT id, login, profile_name AS profileName, password_hash AS passwordHash, subscription_id AS subscriptionId FROM users WHERE login = ? OR email = ? LIMIT 1',
+            [identifier, identifier]
+        );
+        return rows[0] || null;
+    }
+
+    async existsWithLoginOrEmail(login, email) {
+        const [rows] = await this.pool.query(
+            'SELECT id FROM users WHERE login = ? OR email = ? LIMIT 1',
+            [login, email]
+        );
+        return rows.length > 0;
+    }
+
+    async createUser({ login, profileName, email, passwordHash, subscriptionId }) {
+        await this.pool.query(
+            `INSERT INTO users (login, profile_name, email, password_hash, subscription_id, is_admin)
+             VALUES (?, ?, ?, ?, ?, 0)`,
+            [login, profileName, email, passwordHash, subscriptionId || null]
+        );
+    }
+}
+
+module.exports = UserRepository;


### PR DESCRIPTION
## Summary
- refactor the registration and login endpoints into dedicated controller, service, and repository classes
- enable session tracking and expose the authenticated user to the views for dynamic navigation state
- refresh the navigation bar with a profile avatar dropdown, related styling, assets, and client-side behaviour

## Testing
- node public_html/server/app.js *(fails: express module missing in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de7972dbd083339cc2a83e55934e6b