### PR TITLE
Add profile redirect and user settings pages

### DIFF
--- a/public_html/server/app.js
+++ b/public_html/server/app.js
@@ -47,6 +47,13 @@ app.use((req, res, next) => {
     next();
 });
 
+const ensureAuthenticated = (req, res, next) => {
+    if (!req.session.user) {
+        return res.redirect('/register#login');
+    }
+    next();
+};
+
 app.use(express.static(path.join(__dirname, 'public')));
 
 app.set('view engine', 'ejs');
@@ -69,6 +76,25 @@ app.get('/register', authController.showRegister);
 app.post('/register', authController.register);
 app.post('/login', authController.login);
 app.post('/logout', authController.logout);
+
+app.get('/profile', ensureAuthenticated, (req, res) => {
+    const loginSuccess = req.session.loginSuccess;
+    if (loginSuccess) {
+        delete req.session.loginSuccess;
+    }
+
+    res.render('profile', {
+        active: 'profile',
+        profileUser: req.session.user,
+        loginSuccess
+    });
+});
+
+app.get('/settings', ensureAuthenticated, (req, res) => {
+    res.render('settings', {
+        active: 'settings'
+    });
+});
 
 app.get('/api/courses', async (req, res) => {
     try {

--- a/public_html/server/controllers/AuthController.js
+++ b/public_html/server/controllers/AuthController.js
@@ -14,8 +14,7 @@ class AuthController {
         const defaultForm = {
             login: '',
             profileName: '',
-            email: '',
-            subscriptionId: ''
+            email: ''
         };
 
         const defaultMessages = {
@@ -52,8 +51,7 @@ class AuthController {
                 registerForm: {
                     login: req.body.login || '',
                     profileName: req.body.profileName || '',
-                    email: req.body.email || '',
-                    subscriptionId: req.body.subscriptionId || ''
+                    email: req.body.email || ''
                 },
                 messages: {
                     registerErrors: ['Сталася помилка під час створення акаунта. Спробуйте ще раз пізніше.']
@@ -72,10 +70,10 @@ class AuthController {
 
             req.session.user = result.user;
             res.locals.currentUser = result.user;
-            return this.renderRegisterPage(res, {
-                status: result.status,
-                messages: result.messages
-            });
+            if (result.messages && result.messages.loginSuccess) {
+                req.session.loginSuccess = result.messages.loginSuccess;
+            }
+            return res.redirect('/profile');
         } catch (error) {
             console.error('Error logging in user:', error);
             return this.renderRegisterPage(res, {

--- a/public_html/server/public/styles.css
+++ b/public_html/server/public/styles.css
@@ -795,3 +795,287 @@ body {
         padding: 2rem 1.75rem;
     }
 }
+
+/* ——— Profile page ——— */
+.profile-page {
+    display: grid;
+    gap: 2rem;
+}
+
+.profile-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    background: #fff;
+    border-radius: 40px;
+    padding: 2.5rem 3rem;
+    border: 5px solid var(--accent-pink);
+    box-shadow: 0 18px 40px rgba(191, 29, 45, 0.12);
+}
+
+.profile-header__content h1 {
+    font-size: 2rem;
+    margin-bottom: 0.75rem;
+    color: var(--primary-red);
+}
+
+.profile-header__content p {
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.profile-header__avatar img {
+    width: 120px;
+    height: 120px;
+    border-radius: 50%;
+    border: 6px solid var(--accent-pink);
+    background: #fff;
+    box-shadow: 0 12px 24px rgba(191, 29, 45, 0.2);
+    object-fit: cover;
+}
+
+.profile-alert {
+    border-radius: 20px;
+    padding: 1rem 1.25rem;
+    font-weight: 600;
+    line-height: 1.5;
+}
+
+.profile-alert--success {
+    background: rgba(68, 184, 108, 0.12);
+    border: 2px solid rgba(68, 184, 108, 0.35);
+    color: #2f7a4a;
+}
+
+.profile-card {
+    background: #fff;
+    border-radius: 36px;
+    border: 5px solid var(--accent-pink);
+    box-shadow: 0 18px 40px rgba(191, 29, 45, 0.12);
+    padding: 2.25rem 2.5rem;
+    display: grid;
+    gap: 1.5rem;
+}
+
+.profile-card h2 {
+    font-size: 1.6rem;
+    color: var(--primary-red);
+}
+
+.profile-data {
+    list-style: none;
+    display: grid;
+    gap: 1rem;
+}
+
+.profile-data li {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background: var(--soft-cream);
+    border-radius: 18px;
+    padding: 1rem 1.25rem;
+    border: 2px solid rgba(191, 29, 45, 0.15);
+}
+
+.profile-data__label {
+    font-weight: 600;
+    color: var(--text-muted);
+}
+
+.profile-data__value {
+    font-weight: 700;
+    color: var(--text-dark);
+}
+
+.profile-actions {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.profile-action-card {
+    background: #fff;
+    border-radius: 32px;
+    border: 4px solid var(--accent-pink);
+    box-shadow: 0 15px 36px rgba(191, 29, 45, 0.12);
+    padding: 2rem;
+    display: grid;
+    gap: 0.9rem;
+}
+
+.profile-action-card h3 {
+    color: var(--primary-red);
+    font-size: 1.35rem;
+}
+
+.profile-action-card p {
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.profile-action-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    padding: 0.75rem 1.8rem;
+    border-radius: 999px;
+    background: linear-gradient(90deg, var(--primary-red) 0%, #ff6f61 100%);
+    color: #fff;
+    font-weight: 700;
+    text-decoration: none;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.profile-action-btn:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(191, 29, 45, 0.25);
+}
+
+.profile-action-btn--outline {
+    background: #fff;
+    color: var(--primary-red);
+    border: 2px solid var(--primary-red);
+}
+
+.profile-action-btn--outline:hover {
+    box-shadow: none;
+    background: rgba(191, 29, 45, 0.08);
+}
+
+@media (max-width: 768px) {
+    .profile-header {
+        flex-direction: column;
+        text-align: center;
+        gap: 1.5rem;
+    }
+
+    .profile-data li {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 0.35rem;
+    }
+}
+
+/* ——— Settings page ——— */
+.settings-page {
+    display: grid;
+    gap: 2rem;
+}
+
+.settings-header {
+    background: #fff;
+    border-radius: 40px;
+    padding: 2.5rem 3rem;
+    border: 5px solid var(--accent-pink);
+    box-shadow: 0 18px 40px rgba(191, 29, 45, 0.12);
+}
+
+.settings-header h1 {
+    font-size: 2rem;
+    color: var(--primary-red);
+    margin-bottom: 0.75rem;
+}
+
+.settings-header p {
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.settings-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+    gap: 1.5rem;
+}
+
+.settings-card {
+    background: #fff;
+    border-radius: 32px;
+    border: 4px solid var(--accent-pink);
+    box-shadow: 0 15px 36px rgba(191, 29, 45, 0.12);
+    padding: 2rem;
+    display: grid;
+    gap: 1rem;
+}
+
+.settings-card h2 {
+    color: var(--primary-red);
+    font-size: 1.35rem;
+}
+
+.settings-card p {
+    color: var(--text-muted);
+    line-height: 1.6;
+}
+
+.settings-form {
+    display: grid;
+    gap: 0.75rem;
+}
+
+.settings-form label {
+    font-weight: 600;
+    color: var(--text-dark);
+}
+
+.settings-form input {
+    padding: 0.75rem 1rem;
+    border-radius: 14px;
+    border: 2px solid var(--accent-pink);
+    background: var(--soft-cream);
+    transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings-form input:focus {
+    outline: none;
+    border-color: var(--primary-red);
+    box-shadow: 0 0 0 3px rgba(191, 29, 45, 0.2);
+}
+
+.settings-form--stacked {
+    gap: 0.65rem;
+}
+
+.settings-submit {
+    margin-top: 0.5rem;
+    align-self: start;
+    padding: 0.75rem 1.6rem;
+    border-radius: 999px;
+    border: none;
+    background: linear-gradient(90deg, var(--primary-red) 0%, #ff6f61 100%);
+    color: #fff;
+    font-weight: 700;
+    cursor: pointer;
+    transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.settings-submit:hover {
+    transform: translateY(-2px);
+    box-shadow: 0 12px 28px rgba(191, 29, 45, 0.25);
+}
+
+.settings-submit:focus-visible {
+    outline: 3px solid rgba(191, 29, 45, 0.4);
+    outline-offset: 3px;
+}
+
+.settings-note {
+    background: linear-gradient(120deg, rgba(247, 199, 217, 0.4), rgba(248, 214, 117, 0.4));
+    border-radius: 32px;
+    padding: 2rem 2.5rem;
+    border: 3px dashed rgba(191, 29, 45, 0.35);
+    color: var(--text-dark);
+    display: grid;
+    gap: 0.75rem;
+}
+
+.settings-note h2 {
+    font-size: 1.5rem;
+    color: var(--primary-red);
+}
+
+@media (max-width: 768px) {
+    .settings-header {
+        text-align: center;
+    }
+}

--- a/public_html/server/public/views/partials/nav.ejs
+++ b/public_html/server/public/views/partials/nav.ejs
@@ -39,9 +39,12 @@
                     <div class="profile-dropdown" role="menu" data-profile-dropdown>
                         <span class="profile-label">Привіт, <%= currentUser.displayName %></span>
                         <ul class="profile-dropdown__list">
-                            <li><a href="#" role="menuitem">Переглянути профіль</a></li>
-                            <li><a href="#" role="menuitem">Керувати підпискою</a></li>
-                            <li><a href="#" role="menuitem">Налаштування</a></li>
+                            <li>
+                                <a href="/profile" role="menuitem" <%= active==='profile' ? 'aria-current="page"' : '' %>>Переглянути профіль</a>
+                            </li>
+                            <li>
+                                <a href="/settings" role="menuitem" <%= active==='settings' ? 'aria-current="page"' : '' %>>Налаштування</a>
+                            </li>
                         </ul>
                         <div class="profile-dropdown__separator" role="none"></div>
                         <form action="/logout" method="post">

--- a/public_html/server/public/views/profile.ejs
+++ b/public_html/server/public/views/profile.ejs
@@ -1,0 +1,76 @@
+<!DOCTYPE html>
+<html lang="uk">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>NEKO &amp; KOI Academy — Профіль</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Montserrat:wght@400;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="/styles.css" />
+    </head>
+    <body>
+        <%- include('partials/nav', { active, currentUser }) %>
+
+        <main class="section profile-page">
+            <header class="profile-header">
+                <div class="profile-header__content">
+                    <h1>Ваш затишний профіль</h1>
+                    <p>Тут зібрана вся інформація про ваш акаунт у NEKO &amp; KOI Academy.</p>
+                </div>
+                <div class="profile-header__avatar">
+                    <img
+                        src="<%= (profileUser && profileUser.avatarUrl) || '/img/avatar-default.svg' %>"
+                        alt="Аватар профілю"
+                        width="120"
+                        height="120"
+                    />
+                </div>
+            </header>
+
+            <% if (loginSuccess) { %>
+                <div class="profile-alert profile-alert--success"><%= loginSuccess %></div>
+            <% } %>
+
+            <section class="profile-card">
+                <h2>Основні дані</h2>
+                <ul class="profile-data">
+                    <li>
+                        <span class="profile-data__label">Ім'я в профілі</span>
+                        <span class="profile-data__value"><%= (profileUser && profileUser.profileName) || 'Не вказано' %></span>
+                    </li>
+                    <li>
+                        <span class="profile-data__label">Логін</span>
+                        <span class="profile-data__value"><%= profileUser && profileUser.login %></span>
+                    </li>
+                    <li>
+                        <span class="profile-data__label">Електронна адреса</span>
+                        <span class="profile-data__value"><%= (profileUser && profileUser.email) || 'Не вказано' %></span>
+                    </li>
+                    <li>
+                        <span class="profile-data__label">ID підписки</span>
+                        <span class="profile-data__value"><%= (profileUser && profileUser.subscriptionId) ? profileUser.subscriptionId : 'Ще не підключено' %></span>
+                    </li>
+                </ul>
+            </section>
+
+            <section class="profile-actions">
+                <div class="profile-action-card">
+                    <h3>Хочете оновити дані?</h3>
+                    <p>Завітайте на сторінку налаштувань, щоб змінити ім'я, email або пароль.</p>
+                    <a class="profile-action-btn" href="/settings">До налаштувань</a>
+                </div>
+                <div class="profile-action-card">
+                    <h3>Потрібна допомога?</h3>
+                    <p>Напишіть нам через сторінку контактів — ми завжди поруч, щоб підтримати вас.</p>
+                    <a class="profile-action-btn profile-action-btn--outline" href="/contact">Написати нам</a>
+                </div>
+            </section>
+        </main>
+
+        <script src="/js/nav-menu.js" defer></script>
+    </body>
+</html>

--- a/public_html/server/public/views/register.ejs
+++ b/public_html/server/public/views/register.ejs
@@ -84,12 +84,14 @@
                             autocomplete="new-password"
                         />
 
-                        <label for="register-subscription">ID підписки (необов'язково)</label>
+                        <label for="register-password-confirm">Підтвердження пароля *</label>
                         <input
-                            type="text"
-                            id="register-subscription"
-                            name="subscriptionId"
-                            value="<%= registerForm.subscriptionId %>"
+                            type="password"
+                            id="register-password-confirm"
+                            name="passwordConfirm"
+                            minlength="6"
+                            required
+                            autocomplete="new-password"
                         />
 
                         <button type="submit" class="auth-submit">Створити акаунт</button>

--- a/public_html/server/public/views/settings.ejs
+++ b/public_html/server/public/views/settings.ejs
@@ -1,0 +1,77 @@
+<!DOCTYPE html>
+<html lang="uk">
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>NEKO &amp; KOI Academy — Налаштування</title>
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+        <link
+            href="https://fonts.googleapis.com/css2?family=Comfortaa:wght@400;700&family=Montserrat:wght@400;600;700&display=swap"
+            rel="stylesheet"
+        />
+        <link rel="stylesheet" href="/styles.css" />
+    </head>
+    <body>
+        <%- include('partials/nav', { active, currentUser }) %>
+
+        <main class="section settings-page">
+            <header class="settings-header">
+                <h1>Налаштування акаунта</h1>
+                <p>Оберіть, що хочете змінити — і ми допоможемо навести лад у вашому профілі.</p>
+            </header>
+
+            <section class="settings-grid">
+                <article class="settings-card">
+                    <h2>Ім'я профілю</h2>
+                    <p>Оновіть своє відображуване ім'я, щоб друзі впізнавали вас миттєво.</p>
+                    <div class="settings-form">
+                        <label for="profileName">Нове ім'я профілю</label>
+                        <input
+                            type="text"
+                            id="profileName"
+                            name="profileName"
+                            placeholder="Наприклад: SakuraFan"
+                            maxlength="50"
+                        />
+                        <button type="button" class="settings-submit">Зберегти ім'я</button>
+                    </div>
+                </article>
+
+                <article class="settings-card">
+                    <h2>Електронна адреса</h2>
+                    <p>Змінюйте email, якщо переїхали на нову скриньку — ми надішлемо підтвердження.</p>
+                    <div class="settings-form">
+                        <label for="email">Нова адреса</label>
+                        <input type="email" id="email" name="email" placeholder="name@example.com" />
+                        <button type="button" class="settings-submit">Оновити email</button>
+                    </div>
+                </article>
+
+                <article class="settings-card">
+                    <h2>Пароль</h2>
+                    <p>Час від часу змінюйте пароль, щоб акаунт залишався в безпеці.</p>
+                    <div class="settings-form settings-form--stacked">
+                        <label for="currentPassword">Поточний пароль</label>
+                        <input type="password" id="currentPassword" name="currentPassword" autocomplete="current-password" />
+                        <label for="newPassword">Новий пароль</label>
+                        <input type="password" id="newPassword" name="newPassword" autocomplete="new-password" />
+                        <label for="newPasswordConfirm">Підтвердження нового пароля</label>
+                        <input type="password" id="newPasswordConfirm" name="newPasswordConfirm" autocomplete="new-password" />
+                        <button type="button" class="settings-submit">Змінити пароль</button>
+                    </div>
+                </article>
+            </section>
+
+            <section class="settings-note">
+                <h2>Порада дня</h2>
+                <p>
+                    Нехай ваш профіль відображає ваш настрій! Оберіть миле ім'я, а якщо виникнуть труднощі — наша команда підтримки
+                    завжди поруч.
+                </p>
+            </section>
+        </main>
+
+        <script src="/js/nav-menu.js" defer></script>
+    </body>
+</html>

--- a/public_html/server/services/AuthService.js
+++ b/public_html/server/services/AuthService.js
@@ -9,12 +9,11 @@ class AuthService {
         return crypto.createHash('sha256').update(password).digest('hex');
     }
 
-    validateRegisterPayload({ login = '', profileName = '', email = '', password = '', subscriptionId = '' }) {
+    validateRegisterPayload({ login = '', profileName = '', email = '', password = '', passwordConfirm = '' }) {
         const trimmed = {
             login: login.trim(),
             profileName: profileName.trim(),
-            email: email.trim(),
-            subscriptionId: subscriptionId.trim()
+            email: email.trim()
         };
 
         const errors = [];
@@ -40,8 +39,10 @@ class AuthService {
             errors.push('Пароль має містити щонайменше 6 символів.');
         }
 
-        if (trimmed.subscriptionId && trimmed.subscriptionId.length > 32) {
-            errors.push('ID підписки не може бути довшим за 32 символи.');
+        if (!passwordConfirm) {
+            errors.push('Підтвердіть пароль.');
+        } else if (password && password !== passwordConfirm) {
+            errors.push('Паролі не співпадають.');
         }
 
         return { trimmed, errors };
@@ -79,13 +80,13 @@ class AuthService {
             profileName: trimmed.profileName,
             email: trimmed.email,
             passwordHash,
-            subscriptionId: trimmed.subscriptionId
+            subscriptionId: null
         });
 
         return {
             success: true,
             status: 201,
-            registerForm: { login: '', profileName: '', email: '', subscriptionId: '' },
+            registerForm: { login: '', profileName: '', email: '' },
             messages: {
                 registerSuccess: 'Обліковий запис успішно створено! Тепер ви можете увійти.'
             }
@@ -141,6 +142,7 @@ class AuthService {
                 login: user.login,
                 profileName: user.profileName,
                 subscriptionId: user.subscriptionId,
+                email: user.email,
                 displayName,
                 avatarUrl: '/img/avatar-default.svg'
             },

--- a/public_html/server/services/UserRepository.js
+++ b/public_html/server/services/UserRepository.js
@@ -5,7 +5,7 @@ class UserRepository {
 
     async findByLoginOrEmail(identifier) {
         const [rows] = await this.pool.query(
-            'SELECT id, login, profile_name AS profileName, password_hash AS passwordHash, subscription_id AS subscriptionId FROM users WHERE login = ? OR email = ? LIMIT 1',
+            'SELECT id, login, profile_name AS profileName, email, password_hash AS passwordHash, subscription_id AS subscriptionId FROM users WHERE login = ? OR email = ? LIMIT 1',
             [identifier, identifier]
         );
         return rows[0] || null;
@@ -19,7 +19,7 @@ class UserRepository {
         return rows.length > 0;
     }
 
-    async createUser({ login, profileName, email, passwordHash, subscriptionId }) {
+    async createUser({ login, profileName, email, passwordHash, subscriptionId = null }) {
         await this.pool.query(
             `INSERT INTO users (login, profile_name, email, password_hash, subscription_id, is_admin)
              VALUES (?, ?, ?, ?, ?, 0)`,


### PR DESCRIPTION
## Summary
- redirect successful logins straight to the new profile page and guard profile/settings routes with an auth check
- design a cozy profile screen showing stored account details and provide a playful settings hub with action buttons
- simplify registration by dropping the subscription field and requiring password confirmation, updating validation and stored session data

## Testing
- npm install *(fails: registry access is blocked in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68de8e53df9083339c89bdfbf8422b7d